### PR TITLE
Updated packaging sample to latest snapshot, and

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,30 @@ You can find the created distribution under **/target/smarthome-packaging-sample
 
 4. Start runtime
 ================
+
+The minimum requirement for running this distribution is:
+
+* JavaSE 8, JavaSE Embedded 8, or Azul Zulu-Embedded 8
+* When running embedded profiles: at least compact 2 profile
+
+
 Extract the distribution zip file and start the runtime:
 ```
 unzip smarthome-packaging-sample-[version].zip
 ./start.sh
 ```
+
+If you are developing, you can start the distribution with
+
+```
+./start_debug.sh
+```
+
+which will
+* enable debugger on port 5005
+* enable JMX (at least when running on JavaSE compact 3 profile)
+* enable Java Flight Recorder (JFR) when running on Oracle JVM and JFR is installed in JVM
+* provide extended logging output for diagnostic purposes
 
 5. Using the UI
 ================
@@ -118,6 +137,13 @@ You can use `JAVA_OPTS` for passing own parameter to JVM e.g. the Java Heap size
 
 Limitations
 ================
-It's not possible to run XText under concierge due to dependencies on equinox runtime. 
+
+* It's not possible to run XText under concierge due to dependencies on equinox runtime. 
 For this reason all modeling packages have been removed from this distribution. 
 There are no .items, .rule, .thing, etc. files. Try to use new generation rule engine to manage rules.
+* The current distribution does not run on JavaSE compact 2/3 profiles, as
+  * logback-1.1.7 requires at least compact 3
+  * org.eclipse.smarthome.core.scheduler requires quartz, which requires Full-JRE
+  * Same for org.eclipse.smarthome.automation.scheduler
+  * The packaged Jersey-min implementation requires JAXB, which requires Full-JRE
+

--- a/distro/runtime/concierge/smarthome.xargs
+++ b/distro/runtime/concierge/smarthome.xargs
@@ -3,7 +3,7 @@
 # Version configuration
 -Dconcierge.version=5.0.0
 -Djetty.version=9.3.10
--Desh.version=0.9.0.b1
+-Desh.version=0.9.0-SNAPSHOT
 
 # uncomment to clean storage first
 -Dorg.osgi.framework.storage.clean=onFirstInit
@@ -23,6 +23,7 @@
 # -Dorg.eclipse.concierge.debug.packages=true
 # -Dorg.eclipse.concierge.debug.services=true
 # -Dorg.eclipse.concierge.debug.classloading=true
+# -Dorg.eclipse.concierge.debug.resolver=true
 
 # Basic directory - Used for either standard script or when running in IDE
 -Dbase.dir=.
@@ -64,6 +65,7 @@
    javax.security.auth.spi,\ 
    javax.security.auth.x500,\
    javax.security.cert,\
+   javax.sound.sampled,\
    javax.sql,\
    javax.xml,\
    javax.xml.bind,\
@@ -94,31 +96,34 @@
 # -istart ${system.dir}/org.apache.felix.gogo.command-0.*.jar
 # -istart ${system.dir}/org.apache.felix.gogo.shell-0.*.jar
  
-# Concierge extensions, services (fragment, do NOT start)
--istart ${concierge.dir}/org.eclipse.concierge.service.permission-${concierge.version}*.jar
+# Concierge services
 -istart ${concierge.dir}/org.eclipse.concierge.service.packageadmin-${concierge.version}*.jar
 -istart ${concierge.dir}/org.eclipse.concierge.service.startlevel-${concierge.version}*.jar
 -istart ${concierge.dir}/org.eclipse.concierge.service.xmlparser-${concierge.version}*.jar
 
-# Start OSGi services
--istart ${system.dir}/org.osgi.enterprise-*.jar
+# Metatype Service
+-istart ${system.dir}/org.apache.felix.metatype-1.1.2*.jar
 
 # CM Configuration Admin
--istart ${system.dir}/org.apache.felix.configadmin-1.8.8*.jar
+-istart ${system.dir}/org.apache.felix.configadmin-1.8.*.jar
 
 # Events
 -istart ${system.dir}/org.apache.felix.eventadmin-1.4.8*.jar
 
-# Declerativ services DS
--istart ${system.dir}/org.apache.felix.scr-1.8.2*.jar
+# Declarative services DS
+-istart ${system.dir}/org.apache.felix.scr-1.8.*.jar
+
+# OSGi Http Service
+-istart ${system.dir}/org.apache.felix.http.servlet-api-1.1.2*.jar
+-istart ${system.dir}/org.osgi.service.http-1.2.1*.jar
 
 # Enable logging. Use slf4j facade with logback backend. Install bridges for JCL, JUL and log4j
 -install ${system.dir}/slf4j-api-1.7*.jar
--install ${system.dir}/logback-core-1.0.7*.jar
--install ${system.dir}/logback-classic-1.0.7*.jar
+-install ${system.dir}/logback-core-1.1.7*.jar
+-install ${system.dir}/logback-classic-1.1.7*.jar
 -start ${system.dir}/slf4j-api-1.7*.jar
--start ${system.dir}/logback-core-1.0.7*.jar
--start ${system.dir}/logback-classic-1.0.7*.jar
+-start ${system.dir}/logback-core-1.1.7*.jar
+-start ${system.dir}/logback-classic-1.1.7*.jar
 
 # Add Log bridges
 -istart ${system.dir}/jcl-over-slf4j-1.7*.jar
@@ -198,6 +203,10 @@
 -istart ${esh.dir}/org.eclipse.smarthome.core.id-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.storage.mapdb-${esh.version}*.jar
 
+# Eclipse SmartHome Audio/Voice
+-istart ${esh.dir}/org.eclipse.smarthome.core.audio-${esh.version}*.jar
+-istart ${esh.dir}/org.eclipse.smarthome.core.voice-${esh.version}*.jar
+
 # Eclipse SmartHome IO modules
 -istart ${esh.dir}/org.eclipse.smarthome.io.rest-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.io.rest.core-${esh.version}*.jar
@@ -225,11 +234,17 @@
 # Eclipse SmartHome Bindings. Start all bindings here
 -istart ${esh.dir}/org.eclipse.smarthome.binding.yahooweather-${esh.version}*.jar
 
-# FileInstall as last bundle to allow to install add-ons
--istart ${system.dir}/org.apache.felix.fileinstall-3.5.0*.jar
+# Eclipse SmartHome Console extensions
+-istart ${esh.dir}/org.eclipse.smarthome.io.console-${esh.version}*.jar
+
+# Config Dispatch
+-istart ${esh.dir}/org.eclipse.smarthome.config.dispatch-${esh.version}*.jar
 
 # Start webconsole for debugging
 -istart ${system.dir}/org.apache.felix.webconsole-4.2.16-all.jar
+
+# FileInstall as last bundle to allow to install add-ons
+-istart ${system.dir}/org.apache.felix.fileinstall-3.5.0*.jar
 
 
 # end of script

--- a/distro/runtime/concierge/start.sh
+++ b/distro/runtime/concierge/start.sh
@@ -1,51 +1,198 @@
 #!/bin/sh
 
+# Start script to run Eclipse SmartHome on Concierge
+# This script allows you to:
+#   * define your JavaVM via JAVA_HOME
+#   * Set http and https port via HTTP_PORT, HTTPS_PORT. They defaults to 8080, 8443
+#   * Check for minimal Java version: JavaSE 8, compact 2 profile
+#   * when called with "debug" option as first argument:
+#     * will enable Java Flight Recorder (for Oracle JVM only if installed)
+#     * will enable JMX for remote monitoring (when running at least compact3 profile)
+#
+# Returned error codes:
+#   1: $JAVA_HOME/bin/java not found
+#   2: Java Version < 1.8
+#   3: Java Compact 2 at least needed
+#
+
 DIRNAME=`dirname "$0"`
 PROGNAME=`basename "$0"`
 
 RUNTIME_FOLDER=`cd "$DIRNAME/.."; pwd`
 BASE_FOLDER=`cd "$RUNTIME_FOLDER/.."; pwd`
 
-# set ports for HTTP(S) serverputt
+# set ports for HTTP(S) server
 if [ "x$HTTP_PORT" = "x" ]; then
     HTTP_PORT="8080"
 fi
-
 if [ "x$HTTPS_PORT" = "x" ]; then
     HTTPS_PORT="8443"
 fi
 
-# Check Java version. Make sure java command is available
-echo "Using java: $JAVA_HOME" && `java -version`
-VERSION=`java -version 2>&1  | egrep '"([0-9].[0-9]\..*[0-9]).*"' | awk '{print substr($3,2,length($3)-2)}' | awk '{print substr($1, 3, 3)}' | sed -e 's;\.;;g'`
-if [ "$VERSION" -lt "80" ]; then
-   echo "ERROR: JVM must be greater than 1.7"
-   exit 1;
-fi
+# arg 0: debug enabled: true/false
+findJvmVersion() {
+    # use java from JAVA_HOME if set, otherwise java from path, e.g. default java on RaspPi
+    JAVA_BIN=java
+    if [ "x$JAVA_HOME" != "x" ] ; then
+        JAVA_BIN=$JAVA_HOME/bin/java
+        if [ ! -f $JAVA_BIN ] ; then
+            echo "ERROR: could not find $JAVA_BIN"
+            exit 1
+        fi
+    fi
 
-# Find the concierge framework jar
-MAIN=$(find framework -name "org.eclipse.concierge-5.0.0*.jar" | sort | tail -1);
+    # Check Java version. Make sure java command is available
+    JAVA_VERSION_OUTPUT=`$JAVA_BIN -version 2>&1`
+    echo "Using java: $JAVA_BIN"
+    echo "$JAVA_VERSION_OUTPUT"
 
-# Start the framework. Make sure java command is available
-java $JAVA_OPTS \
-	-Dosgi.clean=true \
-	-Dorg.osgi.framework.storage="$BASE_FOLDER/userdata/storage" \
-	-Dosgi.noShutdown=true \
-	-Declipse.ignoreApp=true \
-	-Dsmarthome.servicepid=org.eclipse \
-	-Dsmarthome.logdir="$BASE_FOLDER/userdata/logs" \
-	-Dsmarthome.userdata="$BASE_FOLDER/userdata" \
-	-Dsmarthome.servicecfg="$RUNTIME_FOLDER/etc/services.cfg" \
-	-Dlogback.configurationFile="$RUNTIME_FOLDER/etc/logback_debug.xml" \
-	-Dorg.quartz.properties="$RUNTIME_FOLDER/etc/quartz.properties" \
-	-DmdnsName=smarthome \
-	-Djetty.home="$RUNTIME_FOLDER"/ \
-	-Djetty.etc.config.urls=etc/jetty.xml,etc/jetty-deployer.xml,etc/jetty-selector.xml \
-	-Dorg.osgi.service.http.port=$HTTP_PORT \
-	-Dorg.osgi.service.http.port.secure=$HTTPS_PORT \
-	-Dfelix.fileinstall.dir="$BASE_FOLDER/addons" \
-	-Djava.library.path=lib \
-	-Dfelix.fileinstall.active.level=4 \
-	-Djava.awt.headless=true \
-	-Dfile.encoding="UTF-8" \
-	-jar $MAIN "$DIRNAME/smarthome.xargs"
+    JAVA_VERSION=`echo $JAVA_VERSION_OUTPUT | egrep '"([0-9].[0-9]\..*[0-9]).*"' | awk '{print substr($3,2,length($3)-2)}' | awk '{print substr($1, 3, 3)}' | sed -e 's;\.;;g'`
+    # get information about compact profile (1/2/3/fulljre) and Vendor (Oracle, Azul)
+    JAVA_COMPACT_PROFILE="fulljre"
+    JAVA_VENDOR="Oracle"
+
+    IS_COMPACT1_PROFILE=`echo $JAVA_VERSION_OUTPUT | sed -e 's/^.*compact1.*$/true/g'`
+    if [ "$IS_COMPACT1_PROFILE" = "true" ] ; then JAVA_COMPACT_PROFILE="compact1" ; fi
+    IS_COMPACT2_PROFILE=`echo $JAVA_VERSION_OUTPUT | sed -e 's/^.*compact2.*$/true/g'`
+    if [ "$IS_COMPACT2_PROFILE" = "true" ] ; then JAVA_COMPACT_PROFILE="compact2" ; fi
+    IS_COMPACT3_PROFILE=`echo $JAVA_VERSION_OUTPUT | sed -e 's/^.*compact3.*$/true/g'`
+    if [ "$IS_COMPACT3_PROFILE" = "true" ] ; then JAVA_COMPACT_PROFILE="compact3" ; fi
+    echo "JAVA_COMPACT_PROFILE=$JAVA_COMPACT_PROFILE"
+
+    IS_AZUL_JAVASE=`echo $JAVA_VERSION_OUTPUT | sed -e 's/^.*Zulu-Embedded.*$/true/g'`
+    if [ "$IS_AZUL_JAVASE" = "true" ] ; then JAVA_VENDOR="Azul" ; fi
+    echo "JAVA_VENDOR=$JAVA_VENDOR"
+}
+
+checkJvmVersion() {
+    # Minimal requirement: Java8 with compact2 profile
+    if [ "$JAVA_VERSION" -lt "80" ]; then
+        echo "ERROR: JVM must be greater than 1.7"
+        exit 2;
+    fi
+    if [ "$JAVA_COMPACT_PROFILE" = "compact1" ]; then
+        echo "ERROR: JVM must be at least compact2 profile"
+        exit 3;
+    fi
+}
+
+# arg 0: debug enabled: true/false
+setFlightRecorderOptions() {
+    # in debug mode set Java Flight Recorder (JFR) options when running on Oracle JavaSE
+    JFR_OPTS=""
+    if [ "$1" = "true" ] ; then
+        if [ "$JAVA_VENDOR" = "Oracle" ] ; then
+            # use JFR when $JAVA_HOME/lib/jfr.jar is present (for Full-JRE or customized compact3 profile)
+            # see also https://blogs.oracle.com/jtc/entry/using_java_fligt_recorder_with
+            # in case of JAVA_HOME not set, but fulljre, enable JFR too
+            if [ -f $JAVA_HOME/lib/jfr.jar -o "$JAVA_COMPACT_PROFILE" = "fulljre" ] ; then
+                 # JFR there, so set JFR_OPTS
+                 JFR_OPTS="$JFR_OPTS -XX:+UnlockCommercialFeatures -XX:+FlightRecorder"
+                 # by default, start recording for 5 min, put to userdata folder
+                 JFR_OPTS="$JFR_OPTS -XX:StartFlightRecording=duration=300s,filename=$BASE_FOLDER/userdata/smarthome-concierge.jfr"
+            fi
+       fi
+    fi
+}
+
+# arg 0: debug enabled: true/false
+setJmxOptions() {
+    # enable in debug mode JMX when running on compact3/fulljre
+    JMX_OPTS=""    
+    if [ "$1" = "true" ] ; then
+        if [ "$JAVA_COMPACT_PROFILE" = "compact3" -o "$JAVA_COMPACT_PROFILE" = "fulljre" ]; then
+            # compact3, fulljre: enable JMX in debug mode, needed to flight recorder too
+            JMX_OPTS="$JMX_OPTS -Dcom.sun.management.jmxremote.port=7091"
+            JMX_OPTS="$JMX_OPTS -Dcom.sun.management.jmxremote.rmi.port=7091"
+            JMX_OPTS="$JMX_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+            JMX_OPTS="$JMX_OPTS -Dcom.sun.management.jmxremote.ssl=false"
+        fi
+    fi
+}
+
+# arg 0: debug enabled: true/false
+setDebugOptions() {
+    JAVA_DEBUG_OPTS=""
+    if [ "$1" = "true" ] ; then
+        if [ "$JAVA_VENDOR" = "Azul" -a "$JAVA_COMPACT_PROFILE" = "compact2" ] ; then
+            # will NOT be supported, $JAVA_HOME/lib/libjdwp.so is missing
+            :
+        else
+            DEFAULT_JAVA_DEBUG_PORT="5005"
+            if [ "x$JAVA_DEBUG_PORT" = "x" ]; then
+                JAVA_DEBUG_PORT="$DEFAULT_JAVA_DEBUG_PORT"
+            fi
+            DEFAULT_JAVA_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$JAVA_DEBUG_PORT"
+            JAVA_DEBUG_OPTS="$JAVA_DEBUG_OPTS $DEFAULT_JAVA_DEBUG_OPTS"
+        fi
+
+        # chatty logging setttings
+        JAVA_DEBUG_OPTS="$JAVA_DEBUG_OPTS -Dlogback.configurationFile=$RUNTIME_FOLDER/etc/logback_debug.xml"
+    else
+        # more silent logging setttings
+        JAVA_DEBUG_OPTS="$JAVA_DEBUG_OPTS -Dlogback.configurationFile=$RUNTIME_FOLDER/etc/logback.xml"
+    fi
+}
+
+run() {
+    DEBUG_ENABLED=false
+    while [ "$1" != "" ]; do
+        case $1 in
+            'debug')
+                DEBUG_ENABLED=true
+                shift
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    findJvmVersion $DEBUG_ENABLED
+    checkJvmVersion
+
+    setDebugOptions $DEBUG_ENABLED
+    setFlightRecorderOptions $DEBUG_ENABLED
+    setJmxOptions $DEBUG_ENABLED
+
+    # Find the concierge framework jar
+    MAIN=$(find framework -name "org.eclipse.concierge-5.0.0*.jar" | sort | tail -1);
+
+    # show java command when debug enabled 
+    if [ "$DEBUG_ENABLED" = "true" ] ; then
+        # echo "JAVA_OPTS=$JAVA_OPTS"
+        # echo "JAVA_DEBUG_OPTS=$JAVA_DEBUG_OPTS"
+        # echo "JFR_OPTS=$JFR_OPTS"
+        # echo "JMX_OPTS=$JMX_OPTS"
+        set -x
+    fi
+
+    $JAVA_BIN $JAVA_OPTS $JAVA_DEBUG_OPTS $JFR_OPTS $JMX_OPTS \
+	    -Djava.awt.headless=true \
+	    -Djava.library.path=lib \
+	    -Dfile.encoding="UTF-8" \
+	    -Dosgi.clean=true \
+	    -Dosgi.noShutdown=true \
+	    -Dorg.osgi.framework.storage="$BASE_FOLDER/userdata/storage" \
+	    -Dorg.osgi.service.http.port=$HTTP_PORT \
+	    -Dorg.osgi.service.http.port.secure=$HTTPS_PORT \
+	    -Declipse.ignoreApp=true \
+	    -Djetty.home="$RUNTIME_FOLDER"/ \
+	    -Djetty.etc.config.urls=etc/jetty.xml,etc/jetty-deployer.xml,etc/jetty-selector.xml \
+	    -Dsmarthome.servicepid=org.eclipse \
+	    -Dsmarthome.userdata="$BASE_FOLDER/userdata" \
+	    -Dsmarthome.logdir="$BASE_FOLDER/userdata/logs" \
+	    -Dsmarthome.servicecfg="$RUNTIME_FOLDER/etc/services.cfg" \
+	    -Dsmarthome.configdir="$BASE_FOLDER/conf" \
+	    -Dorg.quartz.properties="$RUNTIME_FOLDER/etc/quartz.properties" \
+	    -Dfelix.fileinstall.dir="$BASE_FOLDER/addons" \
+	    -Dfelix.fileinstall.active.level=4 \
+	    -DmdnsName=smarthome \
+	    -jar $MAIN "$DIRNAME/smarthome.xargs" "$@"
+}
+
+main() {
+    run "$@"
+}
+
+main "$@"

--- a/distro/runtime/etc/logback.xml
+++ b/distro/runtime/etc/logback.xml
@@ -1,0 +1,54 @@
+<configuration scan="true">
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-30.30logger{36}:%-5line] - %msg%ex{10}%n</pattern>
+		</encoder>
+	</appender>
+
+	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
+		<file>${smarthome.logdir:-userdata/logs}/smarthome.log</file>
+		<encoder>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-30.30logger{36}:%-5line] - %msg%ex{10}%n</pattern>
+		</encoder>
+	</appender>
+
+	<appender name="EVENTFILE"
+		class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>${smarthome.logdir:-userdata/logs}/events.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<!-- weekly rollover and archiving -->
+			<fileNamePattern>${smarthome.logdir:-userdata/logs}/events-%d{yyyy-ww}.log.zip</fileNamePattern>
+
+			<!-- maximum number of archive files to keep -->
+			<maxHistory>26</maxHistory>
+		</rollingPolicy>
+		<encoder>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="smarthome.event" level="INFO" additivity="false">
+		<appender-ref ref="EVENTFILE" />
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+	<logger name="org.eclipse.smarthome" level="INFO" />
+
+	<logger name="org.eclipse.jetty" level="INFO" />
+    <logger name="org.jupnp" level="INFO"/>
+ 	<!-- temporary workaround for https://github.com/openhab/jmdns/issues/12 -->
+    <logger name="javax.jmdns" level="OFF"/>
+    <logger name="javax.jmdns.impl" level="OFF"/>
+    <logger name="javax.jmdns.impl.constants" level="OFF"/>
+    <logger name="tuwien.auto.calimero" level="WARN" />
+
+	<root level="WARN">
+		<appender-ref ref="FILE" />
+		<appender-ref ref="STDOUT" />
+	</root>
+
+	<!-- temporary workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=402750 -->
+	<logger name="OSGi" level="OFF" />
+	
+</configuration>

--- a/distro/runtime/etc/services.cfg
+++ b/distro/runtime/etc/services.cfg
@@ -31,4 +31,4 @@ org.eclipse.smarthome.threadpool:thingHandler=3
 org.eclipse.smarthome.threadpool:discovery=3
 
 # Non-scheduled thread pools can also provide a max size
-org.eclipse.smarthome.threadpool:safeCall=3,10
+org.eclipse.smarthome.threadpool:safeCall=3

--- a/distro/start.sh
+++ b/distro/start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # Launch concierge runtime
-cd runtime/concierge && ./start.sh
+cd runtime/concierge && ./start.sh "${@}"

--- a/distro/start_debug.sh
+++ b/distro/start_debug.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+DIRNAME=`dirname "$0"`
+exec "${DIRNAME}/start.sh" debug "${@}"

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <jetty.version>9.3.10.M0</jetty.version>
-        <esh.version>0.9.0.b1</esh.version>
+        <esh.version>0.9.0-SNAPSHOT</esh.version>
     </properties>
 
     <build>
@@ -163,6 +163,17 @@
             <version>${esh.version}</version>
         </dependency>
 
+        <!-- Eclipse Smarthome Core - Audio / Voice -->
+        <dependency>
+            <groupId>org.eclipse.smarthome.core</groupId>
+            <artifactId>org.eclipse.smarthome.core.audio</artifactId>
+            <version>${esh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.smarthome.core</groupId>
+            <artifactId>org.eclipse.smarthome.core.voice</artifactId>
+            <version>${esh.version}</version>
+        </dependency>
 
         <!-- Eclipse Smarthome dependencies - CONFIG -->
         <dependency>
@@ -178,6 +189,11 @@
         <dependency>
             <groupId>org.eclipse.smarthome.config</groupId>
             <artifactId>org.eclipse.smarthome.config.xml</artifactId>
+            <version>${esh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.smarthome.config</groupId>
+            <artifactId>org.eclipse.smarthome.config.dispatch</artifactId>
             <version>${esh.version}</version>
         </dependency>
 
@@ -304,8 +320,8 @@
         <!-- OSGI http services -->
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.enterprise</artifactId>
-            <version>5.0.0</version>
+            <artifactId>org.osgi.service.http</artifactId>
+            <version>1.2.1</version>
         </dependency>
 
         <!-- Felix dependencies -->
@@ -317,7 +333,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configadmin</artifactId>
-            <version>1.8.8</version>
+            <version>1.8.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -328,6 +344,11 @@
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr</artifactId>
             <version>1.8.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.metatype</artifactId>
+            <version>1.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
@@ -349,6 +370,16 @@
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.gogo.shell</artifactId>
             <version>0.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.servlet-api</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.api</artifactId>
+            <version>3.0.0</version>
         </dependency>
 
         <!-- Jetty dependencies -->
@@ -400,12 +431,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.0.7</version>
+            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.7</version>
+            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/assemble/concierge.xml
+++ b/src/assemble/concierge.xml
@@ -46,7 +46,10 @@
             <fileMode>0644</fileMode>
             <directoryMode>0755</directoryMode>
             <includes>
-                <include>bundles/*.jar</include>
+                <include>bundles/org.eclipse.concierge.service.packageadmin*.jar</include>
+                <include>bundles/org.eclipse.concierge.service.startlevel*.jar</include>
+                <include>bundles/org.eclipse.concierge.service.xmlparser*.jar</include>
+                <include>bundles/org.eclipse.concierge.shell*.jar</include>
                 <include>framework/*.jar</include>
                 <include>*.html</include>
             </includes>
@@ -75,7 +78,7 @@
             <fileMode>0644</fileMode>
 
             <includes>
-                <include>org.osgi.enterprise-*</include>
+                <include>org.osgi.service.http-*</include>
 
                 <!-- Logging -->
                 <include>*slf4j*-*</include>
@@ -104,6 +107,8 @@
                 <include>org.apache.felix.configadmin*</include>
                 <include>org.apache.felix.scr*</include>
                 <include>org.apache.felix.eventadmin*</include>
+                <include>org.apache.felix.metatype*</include>
+                <include>org.apache.felix.http*</include>
                 <include>org.apache.felix.webconsole-4.2*</include>
 
                 <!-- Apache GoGo console -->


### PR DESCRIPTION
* change build to use ESH 0.9.0-SNAPSHOT
* added start script with debugging enabled
* extended start.sh script to check for compact profiles, add
debugging/JMX/JavaFlightRecorder if supported by JVM
* separate logback configuration for start with/without debugging
* replaced org.osgi.enterprise.jar with OSGi HttpService API bundle,
Apache Felix Servlet-API bundle and Apache Felix Metatype bundle (less
footprint)
* updated Apache Felix ConfigAdmin to 1.8.10
* updated logback to 1.1.7 (supports compact 3 profile)
* removed Concierge permission bundle from distribution (not needed)
* added ESH core audio/voice bundles
* added ESH config dispatch bundle (needed to dispatch config entries)
* added ESH io console extension
* fixed warning for wrong configured maximum thread pool size

Signed-off-by: Jochen Hiller <j.hiller@telekom.de>