### PR TITLE
Add bootdelegation for javax.script

### DIFF
--- a/distro/runtime/concierge/smarthome.xargs
+++ b/distro/runtime/concierge/smarthome.xargs
@@ -38,7 +38,8 @@
 -Dorg.osgi.framework.bootdelegation=\
    com.sun.org.apache.xerces.internal.jaxp,\
    sun.misc,\
-   sun.reflect
+   sun.reflect,\
+   javax.script
 
 
 -Dorg.osgi.framework.system.packages.extra=\


### PR DESCRIPTION
I was not able to use a bundle which uses javax.script. With this change, that package is added to the list of `org.osgi.framework.bootdelegation` to pass it to the original ClassLoader.

Signed-off-by: Sebastian Janzen <sebastian.janzen@innoq.com>