### PR TITLE
updated sample packaging

### DIFF
--- a/distro/runtime/concierge/smarthome.xargs
+++ b/distro/runtime/concierge/smarthome.xargs
@@ -2,8 +2,8 @@
 
 # Version configuration
 -Dconcierge.version=5.0.0
--Djetty.version=9.3.10
--Desh.version=0.9.0.b4
+-Djetty.version=9.3.21
+-Desh.version=0.9.0.b6
 
 # uncomment to clean storage first
 -Dorg.osgi.framework.storage.clean=onFirstInit
@@ -110,8 +110,8 @@
 # Events
 -istart ${system.dir}/org.apache.felix.eventadmin-1.4.8*.jar
 
-# Declerativ services DS
--istart ${system.dir}/org.apache.felix.scr-1.8.*.jar
+# Declarative services DS
+-istart ${system.dir}/org.apache.felix.scr-1.8.2*.jar
 
 # OSGi Http Service
 -istart ${system.dir}/org.apache.felix.http.servlet-api-1.1.2*.jar
@@ -172,14 +172,11 @@
 # Jetty Client
 -istart ${jetty.dir}/jetty-client-${jetty.version}*.jar
 
-# Persistence: MapDB
--istart ${system.dir}/mapdb-1.0.9*.jar
-
-# jUPnP
+# jUPNP
 -istart ${system.dir}/org.jupnp-2.2.0*.jar
 
-# JmDNS
--istart ${system.dir}/jmdns-3.5.1*.jar
+# jMDNS
+-istart ${system.dir}/jmdns-3.5.3*.jar
 
 # Eclipse SmartHome modules
 -istart ${esh.dir}/org.eclipse.smarthome.core-${esh.version}*.jar
@@ -196,7 +193,7 @@
 -istart ${esh.dir}/org.eclipse.smarthome.core.scheduler-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.core.transform-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.core.id-${esh.version}*.jar
--istart ${esh.dir}/org.eclipse.smarthome.storage.mapdb-${esh.version}*.jar
+-istart ${esh.dir}/org.eclipse.smarthome.storage.json-${esh.version}*.jar
 
 # Eclipse SmartHome Audio/Voice
 -istart ${esh.dir}/org.eclipse.smarthome.core.audio-${esh.version}*.jar
@@ -216,18 +213,20 @@
 -istart ${esh.dir}/org.eclipse.smarthome.automation.commands-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.automation.core-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.automation.parser.gson-${esh.version}*.jar
--istart ${esh.dir}/org.eclipse.smarthome.automation.providers-${esh.version}*.jar
+-install ${esh.dir}/org.eclipse.smarthome.automation.providers-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.automation.rest-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.automation.module.core-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.automation.module.script-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.automation.module.script.defaultscope-${esh.version}*.jar
 -istart ${esh.dir}/org.eclipse.smarthome.automation.module.timer-${esh.version}*.jar
+-start ${esh.dir}/org.eclipse.smarthome.automation.providers-${esh.version}*.jar
 
 # Eclipse SmartHome UI
 -istart ${esh.dir}/org.eclipse.smarthome.ui.paper-${esh.version}*.jar
 
-# Eclipse SmartHome Bindings. Start all bindings here
--istart ${esh.dir}/org.eclipse.smarthome.binding.yahooweather-${esh.version}*.jar
+# Eclipse Smarthome IoT Market
+-istart ${esh.dir}/org.eclipse.smarthome.extensionservice.marketplace-${esh.version}*.jar
+-istart ${esh.dir}/org.eclipse.smarthome.extensionservice.marketplace.automation-${esh.version}*.jar
 
 # Eclipse SmartHome Console extensions
 -istart ${esh.dir}/org.eclipse.smarthome.io.console-${esh.version}*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     </description>
 
     <properties>
-        <jetty.version>9.3.10.M0</jetty.version>
-        <esh.version>0.9.0.b4</esh.version>
+        <jetty.version>9.3.21.v20170918</jetty.version>
+        <esh.version>0.9.0.b6</esh.version>
     </properties>
 
     <build>
@@ -58,6 +58,7 @@
                                 org.eclipse.smarthome.binding,
                                 org.eclipse.smarthome.core,
                                 org.eclipse.smarthome.config,
+                                org.eclipse.smarthome.extensionservice,
                                 org.eclipse.smarthome.io,
                                 org.eclipse.smarthome.automation,
                                 org.eclipse.smarthome.storage,
@@ -299,7 +300,7 @@
         <!-- Eclipse Smarthome dependencies - Storage -->
         <dependency>
             <groupId>org.eclipse.smarthome.storage</groupId>
-            <artifactId>org.eclipse.smarthome.storage.mapdb</artifactId>
+            <artifactId>org.eclipse.smarthome.storage.json</artifactId>
             <version>${esh.version}</version>
         </dependency>
 
@@ -310,10 +311,15 @@
             <version>${esh.version}</version>
         </dependency>
 
-        <!-- Eclipse Smarthome dependencies - Bindings -->
+        <!-- Eclipse Smarthome dependencies - IoT Market -->
         <dependency>
-            <groupId>org.eclipse.smarthome.binding</groupId>
-            <artifactId>org.eclipse.smarthome.binding.yahooweather</artifactId>
+            <groupId>org.eclipse.smarthome.extensionservice</groupId>
+            <artifactId>org.eclipse.smarthome.extensionservice.marketplace</artifactId>
+            <version>${esh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.smarthome.extensionservice</groupId>
+            <artifactId>org.eclipse.smarthome.extensionservice.marketplace.automation</artifactId>
             <version>${esh.version}</version>
         </dependency>
 
@@ -532,18 +538,11 @@
             <version>4.3.6</version>
         </dependency>
 
-        <!-- MapDB -->
-        <dependency>
-            <groupId>org.mapdb</groupId>
-            <artifactId>mapdb</artifactId>
-            <version>1.0.9</version>
-        </dependency>
-
         <!-- JmDNS -->
         <dependency>
             <groupId>org.jmdns</groupId>
             <artifactId>jmdns</artifactId>
-            <version>3.5.1</version>
+            <version>3.5.3</version>
         </dependency>
 
         <!-- jUpnp -->


### PR DESCRIPTION
- switched to ESH 0.9.0.b6
- switched to Jetty 9.3.21
- switched to JmDNS 3.5.3
- replaced MapDB storage by JSON storage
- included Eclipse IoT Market integration

Signed-off-by: Kai Kreuzer <kai@openhab.org>