### PR TITLE
updated to JUPnP 2.3.0 and removed Apache HTTP client dependency

### DIFF
--- a/distro/runtime/concierge/smarthome.xargs
+++ b/distro/runtime/concierge/smarthome.xargs
@@ -165,15 +165,11 @@
 -istart ${jetty.dir}/jetty-deploy-${jetty.version}*.jar
 -istart ${jetty.dir}/jetty-osgi-boot-${jetty.version}*.jar
 
-# HTTP client
--istart ${system.dir}/httpcore-osgi-4.3.3*.jar
--istart ${system.dir}/httpclient-osgi-4.3.6*.jar
-
 # Jetty Client
 -istart ${jetty.dir}/jetty-client-${jetty.version}*.jar
 
 # jUPNP
--istart ${system.dir}/org.jupnp-2.2.0*.jar
+-istart ${system.dir}/org.jupnp-2.3.0*.jar
 
 # jMDNS
 -istart ${system.dir}/jmdns-3.5.3*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -526,18 +526,6 @@
             <version>1.0.0-v20070606</version>
         </dependency>
 
-        <!-- Http client -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore-osgi</artifactId>
-            <version>4.3.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-osgi</artifactId>
-            <version>4.3.6</version>
-        </dependency>
-
         <!-- JmDNS -->
         <dependency>
             <groupId>org.jmdns</groupId>
@@ -545,11 +533,11 @@
             <version>3.5.3</version>
         </dependency>
 
-        <!-- jUpnp -->
+        <!-- jUPnP -->
         <dependency>
             <groupId>org.jupnp</groupId>
             <artifactId>org.jupnp</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.0</version>
         </dependency>
     </dependencies>
 
@@ -557,11 +545,6 @@
         <repository>
             <id>osgi-bundles</id>
             <url>https://dl.bintray.com/maggu2810/maven</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>jupnp</id>
-            <url>https://dl.bintray.com/jupnp/mvn/</url>
             <layout>default</layout>
         </repository>
         <repository>


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>