### PR TITLE
Java 11 support

### DIFF
--- a/distro/runtime/concierge/start.sh
+++ b/distro/runtime/concierge/start.sh
@@ -46,7 +46,7 @@ findJvmVersion() {
     echo "Using java: $JAVA_BIN"
     echo "$JAVA_VERSION_OUTPUT"
 
-    JAVA_VERSION=`echo $JAVA_VERSION_OUTPUT | egrep '"([0-9].[0-9]\..*[0-9]).*"' | awk '{print substr($3,2,length($3)-2)}' | awk '{print substr($1, 3, 3)}' | sed -e 's;\.;;g'`
+    JAVA_VERSION=`echo $JAVA_VERSION_OUTPUT | egrep '"([0-9]{1,2}.[0-9]\.(.*[0-9])?).*"' | awk '{print substr($3,2,length($3)-2)}' | sed -e 's;\.;;g'`
     # get information about compact profile (1/2/3/fulljre) and Vendor (Oracle, Azul)
     JAVA_COMPACT_PROFILE="fulljre"
     JAVA_VENDOR="Oracle"

--- a/distro/runtime/concierge/start.sh
+++ b/distro/runtime/concierge/start.sh
@@ -46,7 +46,7 @@ findJvmVersion() {
     echo "Using java: $JAVA_BIN"
     echo "$JAVA_VERSION_OUTPUT"
 
-    JAVA_VERSION=`echo $JAVA_VERSION_OUTPUT | egrep '"([0-9]{1,2}.[0-9]\.(.*[0-9])?).*"' | awk '{print substr($3,2,length($3)-2)}' | sed -e 's;\.;;g'`
+    JAVA_VERSION=`echo $JAVA_VERSION_OUTPUT | egrep '"([0-9]{1,2}.[0-9]\.(.*[0-9])?).*"' | awk '{print substr($3,2,length($3)-2)}' | sed -e 's;\.;;g'` | sed -e 's;_.*;;g'
     # get information about compact profile (1/2/3/fulljre) and Vendor (Oracle, Azul)
     JAVA_COMPACT_PROFILE="fulljre"
     JAVA_VENDOR="Oracle"
@@ -66,8 +66,8 @@ findJvmVersion() {
 
 checkJvmVersion() {
     # Minimal requirement: Java8 with compact2 profile
-    if [ "$JAVA_VERSION" -lt "80" ]; then
-        echo "ERROR: JVM must be greater than 1.7"
+    if [ "$JAVA_VERSION" -lt "180" ]; then
+        echo "ERROR: JVM version must be 1.8 or later"
         exit 2;
     fi
     if [ "$JAVA_COMPACT_PROFILE" != "fulljre" ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -538,6 +538,12 @@
             <groupId>org.jupnp</groupId>
             <artifactId>org.jupnp</artifactId>
             <version>2.3.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Compilation under JDK 11 fails due to a transitive dependency in [jupnp](https://github.com/jupnp/jupnp) to `tools.jar` which is not available in JDK 11 anymore (see https://github.com/jupnp/jupnp/issues/110). This PR excludes `com.sun.tools` from the build.

Also: Fix an issue in the start script where the java version could not be determined correctly. For Java `1.8.0_121` the extracted version will then be `180`, for Java `11.0.1` the extracted version will be `1101`.