### PR TITLE
Update concierge 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+jdk: oraclejdk8
+
+script:
+  - mvn clean package
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/distro/runtime/concierge/smarthome.xargs
+++ b/distro/runtime/concierge/smarthome.xargs
@@ -1,7 +1,8 @@
 # Concierge start profile for Eclipse SmartHome
 
 # Version configuration
--Dconcierge.version=5.0.0
+# concierge bundles have no unique version anymore
+# we use only major version for bundles
 -Djetty.version=9.3.21
 -Desh.version=0.9.0
 
@@ -30,7 +31,7 @@
 
 # bundle directories
 -Dsystem.dir=${base.dir}/system
--Dconcierge.dir=${base.dir}/bundles
+-Dconcierge.dir=${system.dir}/org.eclipse.concierge
 -Djetty.dir=${system.dir}/org.eclipse.jetty
 -Desh.dir=${system.dir}/org.eclipse.smarthome
 
@@ -91,15 +92,15 @@
 
 
 # OSGi shell. Toggle between concierge shell | Apache Felix GoGo
--istart ${concierge.dir}/org.eclipse.concierge.shell-${concierge.version}*.jar
+-istart ${concierge.dir}/org.eclipse.concierge.shell-*.jar
 # -istart ${system.dir}/org.apache.felix.gogo.runtime-0.*.jar
 # -istart ${system.dir}/org.apache.felix.gogo.command-0.*.jar
 # -istart ${system.dir}/org.apache.felix.gogo.shell-0.*.jar
  
 # Concierge services
--istart ${concierge.dir}/org.eclipse.concierge.service.packageadmin-${concierge.version}*.jar
--istart ${concierge.dir}/org.eclipse.concierge.service.startlevel-${concierge.version}*.jar
--istart ${concierge.dir}/org.eclipse.concierge.service.xmlparser-${concierge.version}*.jar
+-istart ${concierge.dir}/org.eclipse.concierge.service.packageadmin-*.jar
+-istart ${concierge.dir}/org.eclipse.concierge.service.startlevel-*.jar
+-istart ${concierge.dir}/org.eclipse.concierge.service.xmlparser-*.jar
 
 # Metatype Service
 -istart ${system.dir}/org.apache.felix.metatype-1.1.2*.jar
@@ -169,10 +170,10 @@
 -istart ${jetty.dir}/jetty-client-${jetty.version}*.jar
 
 # jUPNP
--istart ${system.dir}/org.jupnp-2.3.0*.jar
+-istart ${system.dir}/org.jupnp-2.*.jar
 
 # jMDNS
--istart ${system.dir}/jmdns-3.5.3*.jar
+-istart ${system.dir}/jmdns-3.*.jar
 
 # Eclipse SmartHome modules
 -istart ${esh.dir}/org.eclipse.smarthome.core-${esh.version}*.jar

--- a/distro/runtime/concierge/start.sh
+++ b/distro/runtime/concierge/start.sh
@@ -46,7 +46,7 @@ findJvmVersion() {
     echo "Using java: $JAVA_BIN"
     echo "$JAVA_VERSION_OUTPUT"
 
-    JAVA_VERSION=`echo $JAVA_VERSION_OUTPUT | egrep '"([0-9]{1,2}.[0-9]\.(.*[0-9])?).*"' | awk '{print substr($3,2,length($3)-2)}' | sed -e 's;\.;;g'` | sed -e 's;_.*;;g'
+    JAVA_VERSION=`echo $JAVA_VERSION_OUTPUT | egrep '"([0-9]{1,2}.[0-9]\.(.*[0-9])?).*"' | awk '{print substr($3,2,length($3)-2)}' | sed -e 's;\.;;g' | sed -e 's;_.*;;g'`
     # get information about compact profile (1/2/3/fulljre) and Vendor (Oracle, Azul)
     JAVA_COMPACT_PROFILE="fulljre"
     JAVA_VENDOR="Oracle"
@@ -166,7 +166,7 @@ run() {
     setJmxOptions $DEBUG_ENABLED
 
     # Find the concierge framework jar
-    MAIN=$(find framework -name "org.eclipse.concierge-5.0.0*.jar" | sort | tail -1);
+    MAIN=$(find system/org.eclipse.concierge -name "org.eclipse.concierge-5.1.0*.jar" | sort | tail -1);
 
     # show java command when debug enabled
     if [ "$DEBUG_ENABLED" = "true" ] ; then

--- a/distro/runtime/etc/logging.properties
+++ b/distro/runtime/etc/logging.properties
@@ -36,5 +36,5 @@ java.util.logging.FileHandler.append       = true
 java.util.logging.FileHandler.formatter    = java.util.logging.SimpleFormatter
 java.util.logging.FileHandler.pattern      = ../../userdata/logs/smarthome-%g.log
 
-java.util.logging.ConsoleHandler.level     = ALL
+java.util.logging.ConsoleHandler.level     = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/distro/runtime/etc/logging_debug.properties
+++ b/distro/runtime/etc/logging_debug.properties
@@ -36,5 +36,5 @@ java.util.logging.FileHandler.append       = true
 java.util.logging.FileHandler.formatter    = java.util.logging.SimpleFormatter
 java.util.logging.FileHandler.pattern      = ../../userdata/logs/smarthome-%g.log
 
-java.util.logging.ConsoleHandler.level     = ALL
+java.util.logging.ConsoleHandler.level     = DEBUG
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/distro/runtime/etc/services.cfg
+++ b/distro/runtime/etc/services.cfg
@@ -21,6 +21,9 @@ org.eclipse.smarthome.binding.sonos:opmlPartnerID=IAeIhU42
 org.jupnp:multicastResponsePort=0
 org.jupnp:asyncThreadPoolSize=30
 org.jupnp:threadPoolSize=15
+# TODO does not yet work to disable these logs
+org.jupnp:specificationViolationReporterEnabled=false
+
 
 com.eclipsesource.jaxrs.connector:root=/rest
 com.eclipsesource.jaxrs.swagger.config:swagger.basePath=/rest

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome-packaging-sample</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -33,7 +33,7 @@
                         </goals>
                         <configuration>
                             <url>
-                                http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/concierge/download/releases/concierge-incubation-5.0.0.zip
+                                http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/concierge/download/releases/concierge-incubation-5.1.0.zip
                             </url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/concierge</outputDirectory>
@@ -46,6 +46,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>copy-concierge-dependencies</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/org.eclipse.concierge</outputDirectory>
+                            <includeArtifactIds>
+                                org.eclipse.concierge,
+                                org.eclipse.concierge.shell,
+                                org.eclipse.concierge.service.packageadmin,
+                                org.eclipse.concierge.service.startlevel,
+                                org.eclipse.concierge.service.xmlparser
+                            </includeArtifactIds>
+                            <ignorePermissions>true</ignorePermissions>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>copy-esh-dependencies</id>
                         <goals>
@@ -116,6 +134,33 @@
     </build>
 
     <dependencies>
+
+        <!-- Eclipse Concierge dependencies based on 5.1.0 distribution -->
+        <dependency>
+            <groupId>org.eclipse.concierge</groupId>
+            <artifactId>org.eclipse.concierge</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.concierge</groupId>
+            <artifactId>org.eclipse.concierge.shell</artifactId>
+            <version>5.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.concierge</groupId>
+            <artifactId>org.eclipse.concierge.service.packageadmin</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.concierge</groupId>
+            <artifactId>org.eclipse.concierge.service.startlevel</artifactId>
+            <version>5.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.concierge</groupId>
+            <artifactId>org.eclipse.concierge.service.xmlparser</artifactId>
+            <version>5.0.0</version>
+        </dependency>
 
         <!-- Eclipse Smarthome dependencies - CORE -->
         <dependency>
@@ -530,14 +575,14 @@
         <dependency>
             <groupId>org.jmdns</groupId>
             <artifactId>jmdns</artifactId>
-            <version>3.5.3</version>
+            <version>3.5.4</version>
         </dependency>
 
         <!-- jUPnP -->
         <dependency>
             <groupId>org.jupnp</groupId>
             <artifactId>org.jupnp</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun</groupId>

--- a/src/assemble/concierge.xml
+++ b/src/assemble/concierge.xml
@@ -40,22 +40,26 @@
 
         <!-- include concierge -->
         <fileSet>
-            <directory>${project.build.directory}/concierge/concierge-incubation-5.0.0/</directory>
+            <directory>${project.build.directory}/concierge/concierge-incubation-5.1.0/</directory>
             <outputDirectory>runtime/concierge</outputDirectory>
             <filtered>false</filtered>
             <fileMode>0644</fileMode>
             <directoryMode>0755</directoryMode>
             <includes>
-                <include>bundles/org.eclipse.concierge.service.packageadmin*.jar</include>
-                <include>bundles/org.eclipse.concierge.service.startlevel*.jar</include>
-                <include>bundles/org.eclipse.concierge.service.xmlparser*.jar</include>
-                <include>bundles/org.eclipse.concierge.shell*.jar</include>
-                <include>framework/*.jar</include>
                 <include>*.html</include>
             </includes>
-            <excludes>
-                <exclude>framework/*-nodebug.jar</exclude>
-            </excludes>
+        </fileSet>
+
+        <!-- include Eclipse Concierge bundles -->
+        <fileSet>
+            <directory>${project.build.directory}/org.eclipse.concierge/</directory>
+            <outputDirectory>runtime/concierge/system/org.eclipse.concierge/</outputDirectory>
+            <filtered>false</filtered>
+            <fileMode>0644</fileMode>
+            <directoryMode>0755</directoryMode>
+            <includes>
+                <include>*.jar</include>
+            </includes>
         </fileSet>
 
         <!-- include Eclipse SmartHome modules -->


### PR DESCRIPTION
* update to Concierge 5.1
* updated jUPnP, jmDNS
* fixed a bug in start.sh where JAVA_VERSION was set wrong
* moved Concierge bundles to .../system/org.eclipse.concierge
* reduced console logging in debug mode a bit
* added travis configuration

Signed-off-by: Jochen Hiller <jochen.hiller@telekom.de>